### PR TITLE
Suggest installing symfony/webpack-encore-bundle instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # WebpackEncoreBundle: Symfony integration with Webpack Encore!
 
-**EXPERIMENTAL** This bundle is currently experimental and under
-development. So, don't use it ;).
+**WARNING** This bundle **IS NOT MAINTAINED** anymore, use
+[symfony/webpack-encore-bundle](https://github.com/symfony/webpack-encore-bundle)
+instead!!!
 
 This bundle allows you to use the `splitEntryChunks()` feature
 from [Webpack Encore](https://symfony.com/doc/current/frontend.html)

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,5 @@
         "symfony/framework-bundle": "^3.4 || ^4.0",
         "symfony/twig-bundle": "^3.4 || ^4.0",
         "symfony/asset": "^3.4 || ^4.0"
-    },
-    "suggest": {
-        "symfony/webpack-encore-bundle": "This bundle has been moved to a new package name: symfony/webpack-encore-bundle - use it instead."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
         "symfony/framework-bundle": "^3.4 || ^4.0",
         "symfony/twig-bundle": "^3.4 || ^4.0",
         "symfony/asset": "^3.4 || ^4.0"
+    },
+    "suggest": {
+        "symfony/webpack-encore-bundle": "This bundle has been moved to a new package name: symfony/webpack-encore-bundle - use it instead."
     }
 }


### PR DESCRIPTION
Fix #2

@weaverryan Could you mark this bundle as "Abandoned" on packagist.org to make it more clear for users to use `symfony/webpack-encore-bundle` instead?
